### PR TITLE
fixes spell infos visible when list emptied

### DIFF
--- a/WowSpellidManager/WinUI3/ViewModels/Helper/HelperSpellViewModel.cs
+++ b/WowSpellidManager/WinUI3/ViewModels/Helper/HelperSpellViewModel.cs
@@ -26,5 +26,10 @@ namespace WowSpellidManager.WinUI3.ViewModels.Helper
         {
             return ((SpecializationViewModel)aSpecialization).Spells.LastOrDefault();
         }
+
+        public bool HasSpells(object aSpecialization)
+        {
+            return ((SpecializationViewModel)aSpecialization).Spells.Any();
+        }
     }
 }

--- a/WowSpellidManager/WinUI3/Views/ClassesView.xaml
+++ b/WowSpellidManager/WinUI3/Views/ClassesView.xaml
@@ -14,10 +14,10 @@
                     RelativePanel.AlignLeftWithPanel="True" 
                     RelativePanel.AlignTopWithPanel="True">
 
-            <AppBarSeparator></AppBarSeparator>
+            <AppBarSeparator Style="{StaticResource InvisibleSeparator}"></AppBarSeparator>
 
             <ListView x:Name="classListView"
-                  SelectionChanged="classListView_SelectionChanged"
+                      SelectionChanged="classListView_SelectionChanged"
                       MaxHeight="550"
                       MinHeight="350"
                       ItemsSource="{Binding}">
@@ -29,7 +29,7 @@
                 </ListView.ItemTemplate>
             </ListView>
 
-            <AppBarSeparator></AppBarSeparator>
+            <AppBarSeparator Style="{StaticResource InvisibleSeparator}"></AppBarSeparator>
 
         </StackPanel>
 

--- a/WowSpellidManager/WinUI3/Views/SpecializationView.xaml.cs
+++ b/WowSpellidManager/WinUI3/Views/SpecializationView.xaml.cs
@@ -65,6 +65,12 @@ namespace WowSpellidManager.WinUI3.Views
         {
             fHelperSpellViewModel.RemoveSpell(fSpecialization, spellListView.SelectedItem);
             spellListView.SelectedItem = fHelperSpellViewModel.GetLastSpellOfSpecialization(fSpecialization);
+
+            if (!fHelperSpellViewModel.HasSpells(fSpecialization)) 
+            {
+                spellDetailsStackPanel.Visibility = Visibility.Collapsed;
+                spellDetailsHeaderStackPanel.Visibility = Visibility.Collapsed;
+            } 
         }
     }
 }

--- a/WowSpellidManager/WinUI3/resources/dictionaries/separators.xaml
+++ b/WowSpellidManager/WinUI3/resources/dictionaries/separators.xaml
@@ -5,17 +5,27 @@
 
     <Style x:Name="width50Separator" TargetType="AppBarSeparator">
         <Setter Property="Width" Value="50"></Setter>
+        <Setter Property="Background" Value="Transparent"></Setter>
+        <Setter Property="Foreground" Value="Transparent"></Setter>
     </Style>
 
     <Style x:Name="horizontalSettingsSeparator" TargetType="AppBarSeparator">
         <Setter Property="Width" Value="100"></Setter>
         <Setter Property="Height" Value="0"></Setter>
+        <Setter Property="Background" Value="Transparent"></Setter>
+        <Setter Property="Foreground" Value="Transparent"></Setter>
     </Style>
 
     <Style x:Name="horizontalSeparatorTiny" TargetType="AppBarSeparator">
         <Setter Property="Width" Value="15"></Setter>
         <Setter Property="Height" Value="1"></Setter>
         <Setter Property="Background" Value="Transparent"></Setter>
+        <Setter Property="Foreground" Value="Transparent"></Setter>
+    </Style>
+
+    <Style x:Name="InvisibleSeparator" TargetType="AppBarSeparator">
+        <Setter Property="Background" Value="Transparent"></Setter>
+        <Setter Property="Foreground" Value="Transparent"></Setter>
     </Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
When the last spell of a specialization was removed, the details section of the spell was still visible.
This now no longer happens.