### PR TITLE
fixed crash when spell id entered was too big

### DIFF
--- a/WowSpellidManager.Domain/Domain/Exceptions/ArgumentGuard.cs
+++ b/WowSpellidManager.Domain/Domain/Exceptions/ArgumentGuard.cs
@@ -29,7 +29,7 @@ namespace WowSpellidManager.Domain.Exceptions
 
         public static void CheckID(string aID)
         {
-            if(!Int32.TryParse(aID, out _))
+            if(!Int64.TryParse(aID, out _))
             {
                 throw new SpellIDNotValidException(nameof(aID));
             }

--- a/WowSpellidManager.Domain/Domain/Models/Spell.cs
+++ b/WowSpellidManager.Domain/Domain/Models/Spell.cs
@@ -12,7 +12,7 @@ namespace WowSpellidManager.Domain.Models
     /// </summary>
     public class Spell : Entity
     {
-        private long fID;
+        private string fID;
         private string fDescription;
         public string Description
         {
@@ -26,7 +26,7 @@ namespace WowSpellidManager.Domain.Models
                 fDescription = value; 
             }
         }
-        public long ID
+        public string ID
         { 
             get 
             { 
@@ -34,18 +34,18 @@ namespace WowSpellidManager.Domain.Models
             }            
             set 
             {
-                ArgumentGuard.CheckID(value.ToString());
+                ArgumentGuard.CheckID(value);
                 fID = value; 
             }
         }
 
-        public Spell(Guid aGuid, string aDesignation, string aDescription, long aID) : base(aGuid, aDesignation)
+        public Spell(Guid aGuid, string aDesignation, string aDescription, string aID) : base(aGuid, aDesignation)
         {
             Description = aDescription;
             ID = aID;
         }
 
-        public Spell(string aDesignation, string aDescription, long aID) : base(aDesignation)
+        public Spell(string aDesignation, string aDescription, string aID) : base(aDesignation)
         {
             Description = aDescription;
             ID = aID;

--- a/WowSpellidManager.Infrastructure/Infrastructure/CRUD/WowClassOperator.cs
+++ b/WowSpellidManager.Infrastructure/Infrastructure/CRUD/WowClassOperator.cs
@@ -32,14 +32,14 @@ namespace WowSpellidManager.Infrastructure.CRUD
             {
                 if (specialization.Designation.Equals("Retribution"))
                 {
-                    specialization.Spells.Add(new Spell("Hammer of Justice", "STUNLOCK", 35976));
-                    specialization.Spells.Add(new Spell("Avenging Wrath", "BIG DAM", 437326));
-                    specialization.Spells.Add(new Spell("Blinding Light", "Area of effect desorient", 553736));
+                    specialization.Spells.Add(new Spell("Hammer of Justice", "STUNLOCK", "35976"));
+                    specialization.Spells.Add(new Spell("Avenging Wrath", "BIG DAM", "437326"));
+                    specialization.Spells.Add(new Spell("Blinding Light", "Area of effect desorient", "553736"));
                 }
 
                 if (specialization.Designation.Equals("Holy"))
                 {
-                    specialization.Spells.Add(new Spell("Word of Glory", "heal", 33625));
+                    specialization.Spells.Add(new Spell("Word of Glory", "heal", "33625"));
                 }
 
             }
@@ -53,15 +53,15 @@ namespace WowSpellidManager.Infrastructure.CRUD
             {
                 if (specialization.Designation.Equals("Arms"))
                 {
-                    specialization.Spells.Add(new Spell("Stormbolt", "30 yard 4 sec stun", 99024));
-                    specialization.Spells.Add(new Spell("Die by the sword", "parry, 40% dmg reduce", 2454200));
-                    specialization.Spells.Add(new Spell("Avatar", "DAM INCREASE", 32134));
+                    specialization.Spells.Add(new Spell("Stormbolt", "30 yard 4 sec stun", "99024"));
+                    specialization.Spells.Add(new Spell("Die by the sword", "parry, 40% dmg reduce", "2454200"));
+                    specialization.Spells.Add(new Spell("Avatar", "DAM INCREASE", "32134"));
                 }
 
                 if (specialization.Designation.Equals("Protection"))
                 {
-                    specialization.Spells.Add(new Spell("Shield Wall", "big deff", 47379));
-                    specialization.Spells.Add(new Spell("Shockwave", "aoe stun", 5446191));
+                    specialization.Spells.Add(new Spell("Shield Wall", "big deff", "47379"));
+                    specialization.Spells.Add(new Spell("Shockwave", "aoe stun", "5446191"));
                 }
 
             }

--- a/WowSpellidManager/WinUI3/ViewModels/Helper/HelperSpellViewModel.cs
+++ b/WowSpellidManager/WinUI3/ViewModels/Helper/HelperSpellViewModel.cs
@@ -14,7 +14,7 @@ namespace WowSpellidManager.WinUI3.ViewModels.Helper
         public void AddSpell(string aSpellName, string aSpellID, string aSpellDescription, object aClass, object aSpecialization)
         {
             fDataOperationProvider.SpellOperator.AddSpell(new Spell(aSpellName, aSpellDescription, 
-                Convert.ToInt64(aSpellID)), ((WowClassViewModel)aClass).WowClass, ((SpecializationViewModel)aSpecialization).Specialization);
+                aSpellID), ((WowClassViewModel)aClass).WowClass, ((SpecializationViewModel)aSpecialization).Specialization);
         }
 
         public void RemoveSpell(object aSpecialization, object aSpell)

--- a/WowSpellidManager/WinUI3/ViewModels/Validators/Checkers/SpellChecker.cs
+++ b/WowSpellidManager/WinUI3/ViewModels/Validators/Checkers/SpellChecker.cs
@@ -10,7 +10,7 @@ namespace WowSpellidManager.WinUI3.ViewModels.Validators.Checkers
     public class SpellChecker
     {
         private Checker fChecker;
-
+        // TODO: add constants for max values etc. here
         public SpellChecker()
         {
             fChecker = new Checker();
@@ -58,6 +58,9 @@ namespace WowSpellidManager.WinUI3.ViewModels.Validators.Checkers
             if (error != null) return error;
 
             error = fChecker.OnlyNumbers(aID, "spell id");
+            if (error != null) return error;
+
+            error = fChecker.MaxCharacters(aID, 12, "spell id");
             if (error != null) return error;
 
             return null;

--- a/WowSpellidManager/WinUI3/ViewModels/Wrapper/SpellViewModel.cs
+++ b/WowSpellidManager/WinUI3/ViewModels/Wrapper/SpellViewModel.cs
@@ -27,7 +27,7 @@ namespace WowSpellidManager.WinUI3.ViewModels.Wrapper
                 Spell.Description = value;
             }
         }
-        public long ID
+        public string ID
         {
             get
             {


### PR DESCRIPTION
- spell id in "Spell" - Model is no longer of type long, now a string
     - in model, a tryparse to long still exists, for safety purposes
- with ui message for wrong input